### PR TITLE
fix warning about headers already sent during cli upgrades

### DIFF
--- a/db/mobile.php
+++ b/db/mobile.php
@@ -23,8 +23,11 @@
  */
 
 defined('MOODLE_INTERNAL') || die();
-// To enable moodle mobile test site to upload my css files.
-header('Access-Control-Allow-Origin: *');
+
+if (defined('CLI_SCRIPT') === false) {
+    // To enable moodle mobile test site to upload my css files.
+    header('Access-Control-Allow-Origin: *');
+}
 
 $addons = array(
     "qtype_regexp" => array(


### PR DESCRIPTION
Bonjour Joseph,

Voici une (très) modeste contribution de Rennes 2 à ton projet. =)

Lorsqu'on exécute le script `admin/cli/upgrade.php` en ligne de commande, un warning PHP s'affiche.
> Warning: Cannot modify header information - headers already sent by (output started at ./admin/cli/upgrade.php:143) in ./question/type/regexp/db/mobile.php on line 27

Je propose donc de ne pas ajouter l'entête lorsque le processus PHP est lancé en ligne de commande.

Qu'en penses-tu ?
