### PR TITLE
Switch away from deprecated grad to gradenoun string.

### DIFF
--- a/edit_regexp_form.php
+++ b/edit_regexp_form.php
@@ -284,7 +284,7 @@ class qtype_regexp_edit_form extends question_edit_form {
         $answeroptions[] = $mform->createElement('text', 'answer',
                         $label, array('size' => 80));
         $answeroptions[] = $mform->createElement('select', 'fraction',
-                        get_string('grade'), $gradeoptions);
+                        get_string('gradenoun'), $gradeoptions);
         $repeated[] = $mform->createElement('group', 'answeroptions',
                         $label, $answeroptions, null, false);
         $repeated[] = $mform->createElement('editor', 'feedback',


### PR DESCRIPTION
Using 'grade' leads to warnings.