### PR TITLE
Fix Typos from recent changes

### DIFF
--- a/backup/moodle2/backup_qtype_regexp_plugin.class.php
+++ b/backup/moodle2/backup_qtype_regexp_plugin.class.php
@@ -57,7 +57,7 @@ class backup_qtype_regexp_plugin extends backup_qtype_plugin {
         // Set source to populate the data.
         // JR changed table name to match new table name system in moodle 2.1 DEC 2011.
         // JR changed field name question to questionid JAN 2012.
-        $regexp->set_source_table('qtype_regexp', ['questionid' => backup::VAR_PARENTID];
+        $regexp->set_source_table('qtype_regexp', ['questionid' => backup::VAR_PARENTID]);
 
         // Don't need to annotate ids nor files.
 

--- a/edit_regexp_form.php
+++ b/edit_regexp_form.php
@@ -107,7 +107,6 @@ class qtype_regexp_edit_form extends question_edit_form {
 
         // Display all correct alternate answers to student on review page :: yes / no.
         $menu = [get_string('no'), get_string('yes')];
-        $menu = [get_string('no'), get_string('yes')];
         $mform->addElement('select', 'studentshowalternate', get_string('studentshowalternate', 'qtype_regexp'), $menu);
         $mform->addHelpButton('studentshowalternate', 'studentshowalternate', 'qtype_regexp');
 


### PR DESCRIPTION
Had a look through the recent commit - https://github.com/rezeau/moodle-qtype_regexp/commit/def99ac7396c156c963295ad73ea30a047d247df

Not sure it will fix #20 but the missing parenthesis might.